### PR TITLE
Fixed typo

### DIFF
--- a/analysis/common_variables.py
+++ b/analysis/common_variables.py
@@ -892,7 +892,7 @@ def generate_common_variables(index_date_variable, exposure_end_date_variable, o
     cov_bin_history_parkison_risk_conditions = patients.minimum_of(
         "tmp_cov_bin_history_rem_sleep_disorder_snomed", 
         "tmp_cov_bin_history_rem_sleep_disorder_hes",
-        "tmp_cov_bin_history_restless_leg_syndrome", 
+        "tmp_cov_bin_history_restless_leg_syndrome_snomed", 
     ),
 
 ################################


### PR DESCRIPTION
Fixed typo for tmp_cov_bin_restless_leg_syndrome to tmp_cov_bin_restless_leg_syndrome_snomed.