### PR TITLE
Removing 18_39-dem_lb cox actions from make_model_output-sub_age

### DIFF
--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -42,7 +42,11 @@ describe <- FALSE # This prints descriptive files for each dataset in the pipeli
 
 # List of models excluded from model output generation
 
-excluded_models <- c("")
+excluded_models <- c(
+  "cohort_vax-sub_age_18_39-dem_lb",
+  "cohort_unvax-sub_age_18_39-dem_lb",
+  "cohort_prevax-sub_age_18_39-dem_lb"
+)
 
 # Create generic action function -----------------------------------------------
 

--- a/project.yaml
+++ b/project.yaml
@@ -12048,7 +12048,6 @@ actions:
     - cox_ipw-cohort_prevax-sub_age_18_39-cis
     - cox_ipw-cohort_prevax-sub_age_18_39-dem_alz
     - cox_ipw-cohort_prevax-sub_age_18_39-dem_any
-    - cox_ipw-cohort_prevax-sub_age_18_39-dem_lb
     - cox_ipw-cohort_prevax-sub_age_18_39-dem_vasc
     - cox_ipw-cohort_prevax-sub_age_18_39-migraine
     - cox_ipw-cohort_prevax-sub_age_18_39-mnd
@@ -12059,7 +12058,6 @@ actions:
     - cox_ipw-cohort_unvax-sub_age_18_39-cis
     - cox_ipw-cohort_unvax-sub_age_18_39-dem_alz
     - cox_ipw-cohort_unvax-sub_age_18_39-dem_any
-    - cox_ipw-cohort_unvax-sub_age_18_39-dem_lb
     - cox_ipw-cohort_unvax-sub_age_18_39-dem_vasc
     - cox_ipw-cohort_unvax-sub_age_18_39-migraine
     - cox_ipw-cohort_unvax-sub_age_18_39-mnd
@@ -12070,7 +12068,6 @@ actions:
     - cox_ipw-cohort_vax-sub_age_18_39-cis
     - cox_ipw-cohort_vax-sub_age_18_39-dem_alz
     - cox_ipw-cohort_vax-sub_age_18_39-dem_any
-    - cox_ipw-cohort_vax-sub_age_18_39-dem_lb
     - cox_ipw-cohort_vax-sub_age_18_39-dem_vasc
     - cox_ipw-cohort_vax-sub_age_18_39-migraine
     - cox_ipw-cohort_vax-sub_age_18_39-mnd


### PR DESCRIPTION
Hopefully very simple: try `make_model_output-sub_age` action to check it works now that I've removed the dependency on 3 failed models