### PR TITLE
Add permissions declaration

### DIFF
--- a/analysis/dataset_definition/dataset_definition_cohorts.py
+++ b/analysis/dataset_definition/dataset_definition_cohorts.py
@@ -1,4 +1,5 @@
 from ehrql import (
+    claim_permissions,
     create_dataset,
 )
 # Bring table definitions from the TPP backend 
@@ -9,6 +10,8 @@ from ehrql.tables.tpp import (
 from ehrql.query_language import table_from_file, PatientFrame, Series
 
 from datetime import date
+
+claim_permissions("appointments")
 
 # Create dataset
 


### PR DESCRIPTION
ehrQL has a new permissions system which requires projects to declare upfront if they need access to any restricted tables. Adding the permission claim will allow the project to continue running locally with dummy data.

As this is an existing project which already has the necessary permissions for running against real data there should be nothing further needed to do.

For more detail see:
https://docs.opensafely.org/ehrql/reference/language/#permissions